### PR TITLE
实现插入事件按照换行切分，为编辑事件添加开始时间标签

### DIFF
--- a/CppMonitor/DAO/imp/ContentLoggerImpl.cs
+++ b/CppMonitor/DAO/imp/ContentLoggerImpl.cs
@@ -30,7 +30,7 @@ namespace NanjingUniversity.CppMonitor.DAO.imp
             try
             {
                 SQLiteConnection conn = dbHelper.getConnection();
-                string sql = "insert into content_info (time,operation,fullpath,textfrom,textto,line,lineoffset) values(@time,@operation,@fullpath,@textfrom,@textto, @lie, @lineoffset)";
+                string sql = "insert into content_info (time,operation,fullpath,textfrom,textto,line,lineoffset,happentime) values(@time,@operation,@fullpath,@textfrom,@textto, @lie, @lineoffset,@happentime)";
                 SQLiteCommand cmd = new SQLiteCommand(sql, conn);
                 //加时间戳
                 string current = DateTime.Now.ToString();
@@ -57,6 +57,9 @@ namespace NanjingUniversity.CppMonitor.DAO.imp
                         case "LineOffset":
                             cmd.Parameters.Add(new SQLiteParameter("@lineoffset", paramPair.Value));
                             break;
+                        case "HappenTime":
+                            cmd.Parameters.Add(new SQLiteParameter("@happentime", paramPair.Value));
+                            break;
                         default:
                             break;
                     }
@@ -79,7 +82,7 @@ namespace NanjingUniversity.CppMonitor.DAO.imp
             SQLiteConnection conn = new SQLiteConnection("Data Source=" + AddressCommon.DBFilePath);
             conn.Open();
             //建立content_info
-            string sql = "create table if not exists content_info (id INTEGER PRIMARY KEY autoincrement, time char[22],operation char[7],fullpath TEXT,textfrom blob,textto blob,line int,lineoffset int)";
+            string sql = "create table if not exists content_info (id INTEGER PRIMARY KEY autoincrement, time char[22],operation char[7],fullpath TEXT,textfrom blob,textto blob,line int,lineoffset int,happentime int8)";
             SQLiteCommand cmd = new SQLiteCommand(sql, conn);
             cmd.ExecuteNonQuery();
             conn.Close();

--- a/CppMonitor/Monitor/ContentMointor/ContentBindEvent.cs
+++ b/CppMonitor/Monitor/ContentMointor/ContentBindEvent.cs
@@ -22,7 +22,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.ContentMointor
 
         private enum RecordKey
         {
-            Operation, FilePath, From, To, Line, LineOffset
+            Operation, FilePath, From, To, Line, LineOffset,HappenTime
         }
     
         private DTE2 Dte2;
@@ -119,6 +119,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.ContentMointor
                 {
                     if(!token.IsCanceled){
                         EditState.FlushBuffer();
+                        SetState(new StartState(this));
                     }
                 });
             }
@@ -193,6 +194,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.ContentMointor
         {
             EditState.FlushBuffer();
             SetState(new DeleteState(this));
+            Context.HappenTime = DateTime.Now.Ticks;
             ReLog(StartPoint, EndPoint, ref ReplacingText, ref ReplacedText);
         }
 
@@ -202,6 +204,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.ContentMointor
         {
             EditState.FlushBuffer();
             SetState(new ReplaceState(this));
+            Context.HappenTime = DateTime.Now.Ticks;
             ReLog(StartPoint, EndPoint, ref ReplacingText, ref ReplacedText);
         }
 
@@ -211,6 +214,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.ContentMointor
         {
             EditState.FlushBuffer();
             SetState(new InsertState(this));
+            Context.HappenTime = DateTime.Now.Ticks;
             ReLog(StartPoint, EndPoint, ref ReplacingText, ref ReplacedText);
         }
 
@@ -263,6 +267,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.ContentMointor
             ));
 
             Context.Buffer.Clear();
+            Context.HappenTime = DateTime.Now.Ticks;//重置操作时间
 
             list.Add(new KeyValuePair<string, object>(
                 ContentUtil.ToUTF8(RecordKey.Line.ToString()),
@@ -272,6 +277,11 @@ namespace NanjingUniversity.CppMonitor.Monitor.ContentMointor
             list.Add(new KeyValuePair<string, object>(
                 ContentUtil.ToUTF8(RecordKey.LineOffset.ToString()),
                 ContentUtil.ToUTF8((Context.LineOffsetBeforeFlush - 1).ToString())
+            ));
+
+            list.Add(new KeyValuePair<string, object>(
+                ContentUtil.ToUTF8(RecordKey.HappenTime.ToString()),
+                Context.HappenTime
             ));
 
             Logger.LogInfo("",list);
@@ -328,6 +338,17 @@ namespace NanjingUniversity.CppMonitor.Monitor.ContentMointor
             set { Context.LastDocContent = value; }
         }
 
+        public long HappenTime
+        {
+            get
+            {
+                return Context.HappenTime;
+            }
+            set
+            {
+                Context.HappenTime = value;
+            }
+        }
         /*====================== Get Property Method End ==================================*/
     }
 }

--- a/CppMonitor/Monitor/ContentMointor/ContextState.cs
+++ b/CppMonitor/Monitor/ContentMointor/ContextState.cs
@@ -75,5 +75,21 @@ namespace NanjingUniversity.CppMonitor.Monitor.ContentMointor
             get { return _LastDocContent; }
             set { _LastDocContent = value; }
         }
+
+        #region 记录变化发生的时间
+        private long happentime;
+
+        public long HappenTime
+        {
+            get
+            {
+                return happentime;
+            }
+            set
+            {
+                happentime = value;
+            }
+        }
+        #endregion
     }
 }

--- a/CppMonitor/Monitor/ContentMointor/State/InsertState.cs
+++ b/CppMonitor/Monitor/ContentMointor/State/InsertState.cs
@@ -86,7 +86,6 @@ namespace NanjingUniversity.CppMonitor.Monitor.ContentMointor.State
                 //    Context.TransferToInsertAfterEnterState(InsertedText);
                 //    return;
                 //}
-
                 // 如果满足以下条件中的任意一个，则聚合所要插入的内容
                 // 1、被插入字符长度 = 前后两次偏移之差 
                 if (OffsetDiff == InsertLength)
@@ -99,16 +98,14 @@ namespace NanjingUniversity.CppMonitor.Monitor.ContentMointor.State
                     if(ReplacingText.EndsWith("\n")){
                         Buffer.Append(ReplacingText);
                         FlushBuffer();
-                        Context.LineBeforeFlush = EndPoint.Line;
-                        Context.LineOffsetBeforeFlush = EndPoint.LineCharOffset;
                     }
                     else
                     {
                         FlushBuffer();
-                        Context.LineBeforeFlush = StartPoint.Line;
-                        Context.LineOffsetBeforeFlush = StartPoint.LineCharOffset;
                         Buffer.Append(ReplacingText);
                     }
+                    Context.LineBeforeFlush = EndPoint.Line;
+                    Context.LineOffsetBeforeFlush = EndPoint.LineCharOffset;
                 }
             }
         }

--- a/CppMonitor/Monitor/ContentMointor/State/InsertState.cs
+++ b/CppMonitor/Monitor/ContentMointor/State/InsertState.cs
@@ -88,17 +88,27 @@ namespace NanjingUniversity.CppMonitor.Monitor.ContentMointor.State
                 //}
 
                 // 如果满足以下条件中的任意一个，则聚合所要插入的内容
-                // 1、被插入字符长度 = 前后两次偏移之差
+                // 1、被插入字符长度 = 前后两次偏移之差 
                 if (OffsetDiff == InsertLength)
                 {
                     Buffer.Append(ReplacingText);
                 }
                 else
                 {
-                    FlushBuffer();
-                    Context.LineBeforeFlush = StartPoint.Line;
-                    Context.LineOffsetBeforeFlush = StartPoint.LineCharOffset;
-                    Buffer.Append(ReplacingText);
+                    //将回车换行汇聚到前一次插入事件 实现按照换行切分插入事件的功能
+                    if(ReplacingText.EndsWith("\n")){
+                        Buffer.Append(ReplacingText);
+                        FlushBuffer();
+                        Context.LineBeforeFlush = EndPoint.Line;
+                        Context.LineOffsetBeforeFlush = EndPoint.LineCharOffset;
+                    }
+                    else
+                    {
+                        FlushBuffer();
+                        Context.LineBeforeFlush = StartPoint.Line;
+                        Context.LineOffsetBeforeFlush = StartPoint.LineCharOffset;
+                        Buffer.Append(ReplacingText);
+                    }
                 }
             }
         }


### PR DESCRIPTION
实现插入事件按照换行切分：用户输入回车会直接出发一次插入操作写数据库动作，也就是表明用户结束了一次插入行为
为编辑事件添加开始时间标签：触发操作的时候记录下时间节点，用的是C#  datetime.now.ticks，在数据库中位int8，对应content_info表中的happentime字段， 表明插入事件的开始时间， 插入事件的结束时间为该条日志的写入时间。

由于这部分代码在原先设计的时候存在缺陷，所以衍进的功能会在极端情况下出现多线程同步问题，（在用户不进行编辑时结束编辑事件的线程 可能会与主线程冲突 ）    鉴于这种情况过于特殊 暂时不做考虑，如果之后发现问题 需要对这部分代码做重构