### PR TITLE
完成5-19插件需求

### DIFF
--- a/CppMonitor/CppMonitor.csproj
+++ b/CppMonitor/CppMonitor.csproj
@@ -174,7 +174,7 @@
     <Compile Include="Monitor\CommandMonitor\ILoggerDaoImpl_stub.cs" />
     <Compile Include="DAO\LoggerFactory.cs" />
     <Compile Include="Guids.cs" />
-    <Compile Include="Monitor\FileMonitor\VsHierarchyEvents.cs" />
+    <Compile Include="Monitor\FileMonitor\ProjectVsHierarchyEvents.cs" />
     <Compile Include="Monitor\FileMonitor\VsSolutionEvent.cs" />
     <Compile Include="ServiceInterop\MonitorService.cs" />
     <Compile Include="Monitor\BuildMonitor\BO\BuildInfo.cs" />

--- a/CppMonitor/CppMonitor.csproj
+++ b/CppMonitor/CppMonitor.csproj
@@ -197,7 +197,7 @@
     <Compile Include="Monitor\ContentMointor\State\StartState.cs" />
     <Compile Include="Monitor\DebugMonitor\DebugBindEvent.cs" />
     <Compile Include="Monitor\DebugMonitor\DebugLogUtil.cs" />
-    <Compile Include="Monitor\FileMonitor\CopyUtil.cs" />
+    <Compile Include="Util\CopyUtil.cs" />
     <Compile Include="Monitor\FileMonitor\FileBindEvent.cs" />
     <Compile Include="Monitor\FileMonitor\FileListener.cs" />
     <Compile Include="Monitor\FileMonitor\FileLogUtil.cs" />

--- a/CppMonitor/CppMonitor.csproj
+++ b/CppMonitor/CppMonitor.csproj
@@ -174,6 +174,8 @@
     <Compile Include="Monitor\CommandMonitor\ILoggerDaoImpl_stub.cs" />
     <Compile Include="DAO\LoggerFactory.cs" />
     <Compile Include="Guids.cs" />
+    <Compile Include="Monitor\FileMonitor\VsHierarchyEvents.cs" />
+    <Compile Include="Monitor\FileMonitor\VsSolutionEvent.cs" />
     <Compile Include="ServiceInterop\MonitorService.cs" />
     <Compile Include="Monitor\BuildMonitor\BO\BuildInfo.cs" />
     <Compile Include="Monitor\BuildMonitor\BO\BuildProjectInfo.cs" />

--- a/CppMonitor/DAO/imp/CommandLoggerImpl.cs
+++ b/CppMonitor/DAO/imp/CommandLoggerImpl.cs
@@ -41,7 +41,7 @@ namespace NanjingUniversity.CppMonitor.DAO.imp
             try
             {
                 SQLiteConnection conn = dbHelper.getConnection();
-                string sql = "insert into command_text (time,action,name,path,content,happentime) values(@time,@action,@name,@path,@content,@happentime)";
+                string sql = "insert into command_text (time,action,name,path,content,happentime,project) values(@time,@action,@name,@path,@content,@happentime,@project)";
                 SQLiteCommand cmd = new SQLiteCommand(sql, conn);
                 //加时间戳
                 string current = DateTime.Now.ToString();
@@ -64,6 +64,9 @@ namespace NanjingUniversity.CppMonitor.DAO.imp
                             break;
                         case "Happentime":
                             cmd.Parameters.Add(new SQLiteParameter("@happentime", paramPair.Value));
+                            break;
+                        case "Project":
+                            cmd.Parameters.Add(new SQLiteParameter("@project", paramPair.Value));
                             break;
                         default:
                             break;
@@ -88,7 +91,7 @@ namespace NanjingUniversity.CppMonitor.DAO.imp
             try
             {
                 SQLiteConnection conn = dbHelper.getConnection();
-                string sql = "insert into command_file (time,action,filepath,pastefilepath,pasteto) values(@time,@action,@filepath,@pastefilepath,@pasteto)";
+                string sql = "insert into command_file (time,action,filepath,pastefilepath,pasteto,project) values(@time,@action,@filepath,@pastefilepath,@pasteto,@project)";
                 SQLiteCommand cmd = new SQLiteCommand(sql, conn);
                 //加时间戳
                 string current = DateTime.Now.ToString();
@@ -108,6 +111,9 @@ namespace NanjingUniversity.CppMonitor.DAO.imp
                             break;
                         case "PasteTo":
                             cmd.Parameters.Add(new SQLiteParameter("@pasteto", paramPair.Value.ToString()));
+                            break;
+                        case "Project":
+                            cmd.Parameters.Add(new SQLiteParameter("@project", paramPair.Value));
                             break;
                         default:
                             break;
@@ -131,11 +137,11 @@ namespace NanjingUniversity.CppMonitor.DAO.imp
             SQLiteConnection conn = new SQLiteConnection("Data Source=" + AddressCommon.DBFilePath);
             conn.Open();
             //建立command_text
-            string sql = "create table if not exists command_text (id INTEGER PRIMARY KEY AUTOINCREMENT, time char[22],action char[10],name TEXT,path TEXT,content TEXT,happentime int8)";
+            string sql = "create table if not exists command_text (id INTEGER PRIMARY KEY AUTOINCREMENT, time char[22],action char[10],name TEXT,path TEXT,content TEXT,happentime int8,project TEXT)";
             SQLiteCommand cmd = new SQLiteCommand(sql, conn);
             cmd.ExecuteNonQuery();
             //建立command_file
-            sql = "create table if not exists command_file (id INTEGER PRIMARY KEY AUTOINCREMENT, time char[22],action char[5],filepath TEXT,pastefilepath TEXT,pasteto TEXT)";
+            sql = "create table if not exists command_file (id INTEGER PRIMARY KEY AUTOINCREMENT, time char[22],action char[5],filepath TEXT,pastefilepath TEXT,pasteto TEXT,project TEXT)";
             cmd = new SQLiteCommand(sql, conn);
             cmd.ExecuteNonQuery();
 

--- a/CppMonitor/DAO/imp/ContentLoggerImpl.cs
+++ b/CppMonitor/DAO/imp/ContentLoggerImpl.cs
@@ -30,7 +30,7 @@ namespace NanjingUniversity.CppMonitor.DAO.imp
             try
             {
                 SQLiteConnection conn = dbHelper.getConnection();
-                string sql = "insert into content_info (time,operation,fullpath,textfrom,textto,line,lineoffset,happentime) values(@time,@operation,@fullpath,@textfrom,@textto, @lie, @lineoffset,@happentime)";
+                string sql = "insert into content_info (time,operation,fullpath,textfrom,textto,line,lineoffset,happentime,project) values(@time,@operation,@fullpath,@textfrom,@textto, @lie, @lineoffset,@happentime,@project)";
                 SQLiteCommand cmd = new SQLiteCommand(sql, conn);
                 //加时间戳
                 string current = DateTime.Now.ToString();
@@ -60,6 +60,9 @@ namespace NanjingUniversity.CppMonitor.DAO.imp
                         case "HappenTime":
                             cmd.Parameters.Add(new SQLiteParameter("@happentime", paramPair.Value));
                             break;
+                        case "Project":
+                            cmd.Parameters.Add(new SQLiteParameter("@project", paramPair.Value.ToString()));
+                            break;
                         default:
                             break;
                     }
@@ -82,7 +85,7 @@ namespace NanjingUniversity.CppMonitor.DAO.imp
             SQLiteConnection conn = new SQLiteConnection("Data Source=" + AddressCommon.DBFilePath);
             conn.Open();
             //建立content_info
-            string sql = "create table if not exists content_info (id INTEGER PRIMARY KEY autoincrement, time char[22],operation char[7],fullpath TEXT,textfrom blob,textto blob,line int,lineoffset int,happentime int8)";
+            string sql = "create table if not exists content_info (id INTEGER PRIMARY KEY autoincrement, time char[22],operation char[7],fullpath TEXT,textfrom blob,textto blob,line int,lineoffset int,happentime int8,project Text)";
             SQLiteCommand cmd = new SQLiteCommand(sql, conn);
             cmd.ExecuteNonQuery();
             conn.Close();

--- a/CppMonitor/Monitor/BuildMonitor/Register/DteBuildRegister.cs
+++ b/CppMonitor/Monitor/BuildMonitor/Register/DteBuildRegister.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.VCProjectEngine;
 using NanjingUniversity.CppMonitor.Monitor.BuildMonitor.Util;
+using NanjingUniversity.CppMonitor.Util;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -71,6 +72,9 @@ namespace NanjingUniversity.CppMonitor.Monitor.BuildMonitor.Register
 
         public void OnBuildBegin(vsBuildScope Scope, vsBuildAction Action)
         {
+            String projectFilePath = Path.Combine(CopyUtil.backupBuildDirPath, DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss"));
+            CopyUtil.backupSolutionFile(projectFilePath);
+
             BuildMonitorManager manager = BuildBindEvent.Manager;
 
             DTE dte = (DTE)ServiceProvider.GlobalProvider.GetService(typeof(EnvDTE.DTE));

--- a/CppMonitor/Monitor/CommandMonitor/ClipBoardDetail/HandleCopy.cs
+++ b/CppMonitor/Monitor/CommandMonitor/ClipBoardDetail/HandleCopy.cs
@@ -21,8 +21,6 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor.ClipBoardDetail
 
         private List<KeyValuePair<String, object>> list;
 
-        private CommandUtil util;
-
         public HandleCopy()
         {
             // TODO: Complete member initialization
@@ -31,7 +29,6 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor.ClipBoardDetail
             DteEvents = Dte.Events;
             DocEvents = DteEvents.DocumentEvents;
             list = new List<KeyValuePair<string, object>>();
-            util = new CommandUtil();
         }
         public void handleText()
         {
@@ -45,6 +42,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor.ClipBoardDetail
                 list.Add(new KeyValuePair<String, object>("Name", Dte.ActiveDocument.Name));
                 list.Add(new KeyValuePair<String, object>("Path", Dte.ActiveDocument.Path));
                 list.Add(new KeyValuePair<String, object>("Content", (string)obj));
+                list.Add(new KeyValuePair<String, object>("Project", doc == null ? "" : doc.ProjectItem.ContainingProject.Name));
             }
             else
             {
@@ -90,11 +88,12 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor.ClipBoardDetail
             list.Add(new KeyValuePair<String, object>("Action", "Copy"));
             list.Add(new KeyValuePair<String, object>("Type", "File"));
             EnvDTE80.DTE2 _applicationObject = (DTE2)Microsoft.VisualStudio.Shell.Package.GetGlobalService(typeof(DTE));
-            List<string> Ie = util.GetSelectedFilePaths(_applicationObject);
+            List<string> Ie = CommandUtil.GetSelectedFilePaths(_applicationObject);
             if(Ie!=null){
                 list.Add(new KeyValuePair<String, object>("FilePath", string.Join(",", Ie)));
 
             }
+            list.Add(new KeyValuePair<String, object>("Project", CommandUtil.GetActiveProjects(Dte as DTE2)));
             ILoggerDaoImpl_stub.CommandLogger.LogFile(list);
 
         }

--- a/CppMonitor/Monitor/CommandMonitor/ClipBoardDetail/HandleCut.cs
+++ b/CppMonitor/Monitor/CommandMonitor/ClipBoardDetail/HandleCut.cs
@@ -22,7 +22,6 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor.ClipBoardDetail
 
         private List<KeyValuePair<String, object>> list;
 
-        private CommandUtil util;
         public HandleCut()
         {
             Dte = (DTE)Microsoft.VisualStudio.Shell.Package.
@@ -30,7 +29,6 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor.ClipBoardDetail
             DteEvents = Dte.Events;
             DocEvents = DteEvents.DocumentEvents;
             list = new List<KeyValuePair<string, object>>();
-            util = new CommandUtil();
         }
 
         public void handleText()
@@ -42,9 +40,10 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor.ClipBoardDetail
             {
                 list.Add(new KeyValuePair<String, object>("Action", "Cut"));
                 list.Add(new KeyValuePair<String, object>("Type", ctype));
-                list.Add(new KeyValuePair<String, object>("Name", Dte.ActiveDocument.Name));
-                list.Add(new KeyValuePair<String, object>("Path", Dte.ActiveDocument.Path));
+                list.Add(new KeyValuePair<String, object>("Name", doc.Name));
+                list.Add(new KeyValuePair<String, object>("Path", doc.Path));
                 list.Add(new KeyValuePair<String, object>("Content", (string)obj));
+                list.Add(new KeyValuePair<String, object>("Project", doc == null ? "" : doc.ProjectItem.ContainingProject.Name));
             }
             else
             {
@@ -86,13 +85,13 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor.ClipBoardDetail
             list.Add(new KeyValuePair<String, object>("Action", "Cut"));
             list.Add(new KeyValuePair<String, object>("Type", "File"));
             EnvDTE80.DTE2 _applicationObject = (DTE2)Microsoft.VisualStudio.Shell.Package.GetGlobalService(typeof(DTE));
-            List<string> Ie = util.GetSelectedFilePaths(_applicationObject);
+            List<string> Ie = CommandUtil.GetSelectedFilePaths(_applicationObject);
             if (Ie != null)
             {
                 list.Add(new KeyValuePair<String, object>("FilePath", string.Join(",",Ie)));
 
             }
-
+            list.Add(new KeyValuePair<String, object>("Project", CommandUtil.GetActiveProjects(Dte as DTE2)));
             ILoggerDaoImpl_stub.CommandLogger.LogFile(list);
         }
     }

--- a/CppMonitor/Monitor/CommandMonitor/ClipBoardDetail/HandlePaste.cs
+++ b/CppMonitor/Monitor/CommandMonitor/ClipBoardDetail/HandlePaste.cs
@@ -24,8 +24,6 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor.ClipBoardDetail
 
         private List<KeyValuePair<String, object>> list;
 
-        private CommandUtil util;
-
         public HandlePaste()
         {
             Dte = (DTE)Microsoft.VisualStudio.Shell.Package.
@@ -33,7 +31,6 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor.ClipBoardDetail
             DteEvents = Dte.Events;
             DocEvents = DteEvents.DocumentEvents;
             list = new List<KeyValuePair<string, object>>();
-            util = new CommandUtil();
         }
         public void handleText()
         {
@@ -47,6 +44,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor.ClipBoardDetail
                 list.Add(new KeyValuePair<String, object>("Name", Dte.ActiveDocument.Name));
                 list.Add(new KeyValuePair<String, object>("Path", Dte.ActiveDocument.Path));
                 list.Add(new KeyValuePair<String, object>("Content", (string)obj));
+                list.Add(new KeyValuePair<String, object>("Project", doc == null ? "" : doc.ProjectItem.ContainingProject.Name));
             }
             else
             {
@@ -73,9 +71,9 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor.ClipBoardDetail
 
             //get the path of paste_to 
             EnvDTE80.DTE2 _applicationObject = (DTE2)Microsoft.VisualStudio.Shell.Package.GetGlobalService(typeof(DTE));
-            string thepath = util.GetSelectedProjectPath(_applicationObject);
+            string thepath = CommandUtil.GetSelectedProjectPath(_applicationObject);
             list.Add(new KeyValuePair<String, object>("PasteTo", thepath));
-
+            list.Add(new KeyValuePair<String, object>("Project", CommandUtil.GetActiveProjects(Dte as DTE2)));
             ILoggerDaoImpl_stub.CommandLogger.LogFile(list);
         }
 
@@ -102,10 +100,10 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor.ClipBoardDetail
 
             //get the path of paste_to 
             EnvDTE80.DTE2 _applicationObject = (DTE2)Microsoft.VisualStudio.Shell.Package.GetGlobalService(typeof(DTE));
-            string thepath = util.GetSelectedProjectPath(_applicationObject);
+            string thepath = CommandUtil.GetSelectedProjectPath(_applicationObject);
             //MessageBox.Show(thepath);
             list.Add(new KeyValuePair<String, object>("PasteTo", thepath));
-
+            list.Add(new KeyValuePair<String, object>("Project", CommandUtil.GetActiveProjects(Dte as DTE2)));
             ILoggerDaoImpl_stub.CommandLogger.LogFile(list);
         }
     }

--- a/CppMonitor/Monitor/CommandMonitor/CommandBindEvent.cs
+++ b/CppMonitor/Monitor/CommandMonitor/CommandBindEvent.cs
@@ -185,6 +185,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor
 
                 BefEventTable[ID].DynamicInvoke();
             }
+
         }
 
         private void AftCmdExecute(string Guid, int ID, object CustomIn,
@@ -196,6 +197,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor
 
                 AftEventTable[ID].DynamicInvoke();
             }
+
         }
 
         /**

--- a/CppMonitor/Monitor/CommandMonitor/CommandBindEvent.cs
+++ b/CppMonitor/Monitor/CommandMonitor/CommandBindEvent.cs
@@ -167,6 +167,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor
             list.Add(new KeyValuePair<String, object>("Name", doc.Name));
             list.Add(new KeyValuePair<String, object>("Path", doc.Path));
             list.Add(new KeyValuePair<String, object>("Content", content));
+            list.Add(new KeyValuePair<String, object>("Project", doc == null ? "" : doc.ProjectItem.ContainingProject.Name));
             ILoggerDaoImpl_stub.CommandLogger.LogText(list);
 
         }
@@ -239,6 +240,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor
             list.Add(new KeyValuePair<String, object>("Name", Doc==null?"":Doc.Name));
             list.Add(new KeyValuePair<String, object>("Path", Doc == null ? "" : Doc.Path));
             list.Add(new KeyValuePair<String, object>("Content", ""));
+            list.Add(new KeyValuePair<String, object>("Project", Doc == null ? "" : Doc.ProjectItem.ContainingProject.Name));
             ILoggerDaoImpl_stub.CommandLogger.LogText(list);
 
         }
@@ -254,6 +256,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor
             list.Add(new KeyValuePair<String, object>("Name", Doc == null ? "" : Doc.Name));
             list.Add(new KeyValuePair<String, object>("Path", Doc == null ? "" : Doc.Path));
             list.Add(new KeyValuePair<String, object>("Content", ""));
+            list.Add(new KeyValuePair<String, object>("Project", Doc == null ? "" : Doc.ProjectItem.ContainingProject.Name));
             ILoggerDaoImpl_stub.CommandLogger.LogText(list);
         }
 
@@ -265,6 +268,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor
             list.Add(new KeyValuePair<String, object>("Name", Doc == null ? "" : Doc.Name));
             list.Add(new KeyValuePair<String, object>("Path", Doc == null ? "" : Doc.Path));
             list.Add(new KeyValuePair<String, object>("Content", ""));
+            list.Add(new KeyValuePair<String, object>("Project", Doc == null ? "" : Doc.ProjectItem.ContainingProject.Name));
             ILoggerDaoImpl_stub.CommandLogger.LogText(list);
         }
 
@@ -276,6 +280,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor
             list.Add(new KeyValuePair<String, object>("Name", Doc == null ? "" : Doc.Name));
             list.Add(new KeyValuePair<String, object>("Path", Doc == null ? "" : Doc.Path));
             list.Add(new KeyValuePair<String, object>("Content", ""));
+            list.Add(new KeyValuePair<String, object>("Project", Doc == null ? "" : Doc.ProjectItem.ContainingProject.Name));
             ILoggerDaoImpl_stub.CommandLogger.LogText(list);
         }
 

--- a/CppMonitor/Monitor/CommandMonitor/CommandUtil.cs
+++ b/CppMonitor/Monitor/CommandMonitor/CommandUtil.cs
@@ -19,7 +19,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor
         {
 
         }
-        public string getDocContent(ProjectItem projectItem)
+        public static string getDocContent(ProjectItem projectItem)
         {
             Document temp = projectItem.Document;
             if (temp != null)
@@ -34,7 +34,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor
             }
         }
 
-        private List<string> LoopFilter(IVCCollection vcFilters)
+        private static List<string> LoopFilter(IVCCollection vcFilters)
         {
             List<string> allPath = new List<string>();
             for (int i = 1; i <= vcFilters.Count; i++)
@@ -58,7 +58,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor
             return allPath;
         }
 
-        private List<string> GetSelectedItemPaths(DTE2 dte)
+        private static List<string> GetSelectedItemPaths(DTE2 dte)
         {
             List<string> list = new List<string>();
             Array items = (Array)dte.ToolWindows.SolutionExplorer.SelectedItems;
@@ -128,7 +128,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor
             return list;
         }
 
-        public List<string> GetSelectedFilePaths(DTE2 dte)
+        public static List<string> GetSelectedFilePaths(DTE2 dte)
         {
             List<string> IE = GetSelectedItemPaths(dte);
             List<string> list = new List<string>();
@@ -155,7 +155,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor
         }
 
 
-        private Project GetSelectedProject(DTE2 dte)
+        public static Project GetSelectedProject(DTE2 dte)
         {
 
             Project project = null;
@@ -183,7 +183,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor
 
         }
 
-        public string GetSelectedProjectPath(DTE2 dte)
+        public static string GetSelectedProjectPath(DTE2 dte)
         {
             string path = "";
             //获取被选中的工程
@@ -198,6 +198,22 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor
             //去掉工程的文件名
             path = Path.GetDirectoryName(path);
 
+            return path;
+
+        }
+
+        //获取当前活跃的项目名
+        public static string GetActiveProjects(DTE2 dte)
+        {
+            string path = "";
+            List<String> projectNames = new List<string>();
+            //获取被选中的工程
+            Array projects = (Array)dte.ActiveSolutionProjects;
+            foreach (Project pro in projects)
+            {
+                projectNames.Add(pro.Name);
+            }
+            path = String.Join(",", projectNames);
             return path;
 
         }

--- a/CppMonitor/Monitor/CommandMonitor/ILoggerDaoImpl_stub.cs
+++ b/CppMonitor/Monitor/CommandMonitor/ILoggerDaoImpl_stub.cs
@@ -35,7 +35,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor
             if(logger != null){
                 List<KeyValuePair<String, Object>> logParams = new List<KeyValuePair<string, object>>();
 
-                HashSet<string> keyNames = new HashSet<string>() { "Action", "Name", "Path", "Content" };
+                HashSet<string> keyNames = new HashSet<string>() { "Action", "Name", "Path", "Content" ,"Project"};
 
                 foreach (KeyValuePair<string, object> item in list)
                 {
@@ -60,7 +60,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.CommandMonitor
             {
                 List<KeyValuePair<String, Object>> logParams = new List<KeyValuePair<string, object>>();
 
-                HashSet<string> keyNames = new HashSet<string>() { "Action", "FilePath", "PasteFileType", "PasteTo" };
+                HashSet<string> keyNames = new HashSet<string>() { "Action", "FilePath", "PasteFileType", "PasteTo", "Project" };
 
                 foreach (KeyValuePair<string, object> item in list)
                 {

--- a/CppMonitor/Monitor/ContentMointor/ContentBindEvent.cs
+++ b/CppMonitor/Monitor/ContentMointor/ContentBindEvent.cs
@@ -22,7 +22,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.ContentMointor
 
         private enum RecordKey
         {
-            Operation, FilePath, From, To, Line, LineOffset,HappenTime
+            Operation, FilePath, From, To, Line, LineOffset,HappenTime,Project
         }
     
         private DTE2 Dte2;
@@ -254,6 +254,11 @@ namespace NanjingUniversity.CppMonitor.Monitor.ContentMointor
             list.Add(new KeyValuePair<string, object>(
                 ContentUtil.ToUTF8(RecordKey.FilePath.ToString()), 
                 ContentUtil.ToUTF8(Context.ActiveDoc.FullName)
+            ));
+
+            list.Add(new KeyValuePair<string, object>(
+                ContentUtil.ToUTF8(RecordKey.Project.ToString()),
+                ContentUtil.ToUTF8(Context.ActiveDoc.ProjectItem.ContainingProject.Name)
             ));
 
             list.Add(new KeyValuePair<string, object>(

--- a/CppMonitor/Monitor/FileMonitor/FileBindEvent.cs
+++ b/CppMonitor/Monitor/FileMonitor/FileBindEvent.cs
@@ -21,6 +21,13 @@ namespace NanjingUniversity.CppMonitor.Monitor.FileMonitor
 
             SolutionListener sl = new SolutionListener(dte, dte2);
             sl.addListener();
+
+            #region vssolutionEvent3
+            IVsSolution solution = ServiceProvider.GlobalProvider.GetService(typeof(SVsSolution)) as IVsSolution;
+            uint cookie = 0;
+            solution.AdviseSolutionEvents(new VsSolutionEvents(), out cookie);
+
+            #endregion
         }
     }
 }

--- a/CppMonitor/Monitor/FileMonitor/FileListener.cs
+++ b/CppMonitor/Monitor/FileMonitor/FileListener.cs
@@ -28,6 +28,7 @@ namespace NanjingUniversity.CppMonitor.Monitor.FileMonitor
             this.middlePath = middlePath;
             vcp.ItemAdded += vcp_ItemAdded;
             vcp.ItemRemoved += vcp_ItemRemoved;
+            vcp.ItemRenamed += vcp_ItemRenamed;
         }
 
         public void removeListener()
@@ -35,7 +36,29 @@ namespace NanjingUniversity.CppMonitor.Monitor.FileMonitor
             //MessageBox.Show("remove listener for file events");
             vcp.ItemAdded -= vcp_ItemAdded;
             vcp.ItemRemoved -= vcp_ItemRemoved;
+            vcp.ItemRenamed -= vcp_ItemRenamed;
         }
+
+        #region rename function
+        void vcp_ItemRenamed(object Item, object ItemParent, string OldName)
+        {
+          VCProjectItem pitem = Item as VCProjectItem;
+          //avoid to get null object
+           if(pitem != null){
+               if (pitem.Kind.Equals("VCFile"))
+               {
+                   VCFile f = Item as VCFile;
+                   FileLogUtil.logFileEvent(5, f.FullPath, (f.project).Name,OldName);//记录日志
+                   String desDir = getDesDir(f.FullPath);
+               }
+               else if (pitem.Kind.Equals("VCFilter"))
+               {
+                   VCFilter f = Item as VCFilter;
+                   FileLogUtil.logFileEvent(6, f.CanonicalName, f.project.Name,OldName);//记录日志
+               }
+          }
+        }
+        #endregion
 
         void vcp_ItemRemoved(object Item, object ItemParent)
         {

--- a/CppMonitor/Monitor/FileMonitor/FileListener.cs
+++ b/CppMonitor/Monitor/FileMonitor/FileListener.cs
@@ -1,5 +1,6 @@
 ﻿using EnvDTE;
 using Microsoft.VisualStudio.VCProjectEngine;
+using NanjingUniversity.CppMonitor.Util;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/CppMonitor/Monitor/FileMonitor/ProjectVsHierarchyEvents.cs
+++ b/CppMonitor/Monitor/FileMonitor/ProjectVsHierarchyEvents.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NanjingUniversity.CppMonitor.Monitor.FileMonitor
+{
+    class ProjectVsHierarchyEvents : IVsHierarchyEvents 
+    {
+        IVsHierarchy _pHierarchy = null;
+        Object _name;
+        public ProjectVsHierarchyEvents(IVsHierarchy pHierarchy)
+        {
+            this._pHierarchy = pHierarchy;
+            _pHierarchy.GetProperty((uint) VSConstants.VSITEMID.Root, (int) __VSHPROPID.VSHPROPID_Caption, out _name);
+        }
+        public int OnInvalidateIcon(IntPtr hicon)
+        {
+            return 0;
+        }
+
+        public int OnInvalidateItems(uint itemidParent)
+        {
+            return 0;
+        }
+
+        public int OnItemAdded(uint itemidParent, uint itemidSiblingPrev, uint itemidAdded)
+        {
+            return 0;
+        }
+
+        public int OnItemDeleted(uint itemid)
+        {
+            return 0;
+        }
+
+        public int OnItemsAppended(uint itemidParent)
+        {
+            return 0;
+        }
+
+        public int OnPropertyChanged(uint itemid, int propid, uint flags)
+        {
+            if (itemid == (uint)VSConstants.VSITEMID.Root && propid == (int)__VSHPROPID.VSHPROPID_Caption)
+            {
+                Object newName = null;
+                _pHierarchy.GetProperty(itemid, propid, out newName);
+                FileLogUtil.logFileEvent(7,newName as string,_name as string,_name as string);
+                _name = newName;
+            }
+           
+            return 0; 
+        }
+    }
+}

--- a/CppMonitor/Monitor/FileMonitor/SolutionListener.cs
+++ b/CppMonitor/Monitor/FileMonitor/SolutionListener.cs
@@ -1,5 +1,6 @@
 ﻿using EnvDTE;
 using EnvDTE80;
+using NanjingUniversity.CppMonitor.Util;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -44,19 +45,11 @@ namespace NanjingUniversity.CppMonitor.Monitor.FileMonitor
             //String name =  solutionFullname.Substring(lindex+1, diff-1);
             //String solutionDir = solutionFullname.Substring(0, lindex);
             //CopyUtil.copyDir(solutionDir, CopyUtil.backupDirPath+"\\"+DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss") + "-"+name);
-            Projects projects = dte.Solution.Projects;
             String projectFilePath = Path.Combine(CopyUtil.backupStartDirPath, DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss"));
+            CopyUtil.backupSolutionFile(projectFilePath);
             //保存信息
-            //MessageBox.Show(mes);
             FileLogUtil.logSolutionOpenEvent(dte2.Solution.FullName,1,mes,projectFilePath);
-            if (!Directory.Exists(projectFilePath))
-            {
-                Directory.CreateDirectory(projectFilePath);
-            }
-            foreach (Project project in projects)
-            {
-                CopyUtil.copyProjectFilesToTmp(project.ProjectItems, Path.Combine(projectFilePath, project.Name));
-            }
+           
             //创建中间文件夹
             String middlePath = Path.Combine(CopyUtil.backupMiddleDirPath, DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss"));
             if (!Directory.Exists(middlePath))

--- a/CppMonitor/Monitor/FileMonitor/VsSolutionEvent.cs
+++ b/CppMonitor/Monitor/FileMonitor/VsSolutionEvent.cs
@@ -1,0 +1,112 @@
+﻿using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NanjingUniversity.CppMonitor.Monitor.FileMonitor
+{
+    class VsSolutionEvents : IVsSolutionEvents3,IVsSolutionEvents4
+    {
+
+        public int OnAfterCloseSolution(object pUnkReserved)
+        {
+            return 0;
+        }
+
+        public int OnAfterClosingChildren(IVsHierarchy pHierarchy)
+        {
+            return 0;
+        }
+
+        public int OnAfterLoadProject(IVsHierarchy pStubHierarchy, IVsHierarchy pRealHierarchy)
+        {
+            return 0;
+        }
+
+        public int OnAfterMergeSolution(object pUnkReserved)
+        {
+            return 0;
+        }
+
+        public int OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)
+        {
+            uint result = 0;
+            pHierarchy.AdviseHierarchyEvents(new ProjectVsHierarchyEvents(pHierarchy), out result);
+            return 0;
+        }
+
+        public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
+        {
+            return 0;
+        }
+
+        public int OnAfterOpeningChildren(IVsHierarchy pHierarchy)
+        {
+            return 0;
+        }
+
+        public int OnBeforeCloseProject(IVsHierarchy pHierarchy, int fRemoved)
+        {
+            return 0;
+        }
+
+        public int OnBeforeCloseSolution(object pUnkReserved)
+        {
+            return 0;
+        }
+
+        public int OnBeforeClosingChildren(IVsHierarchy pHierarchy)
+        {
+            return 0;
+        }
+
+        public int OnBeforeOpeningChildren(IVsHierarchy pHierarchy)
+        {
+            return 0;
+        }
+
+        public int OnBeforeUnloadProject(IVsHierarchy pRealHierarchy, IVsHierarchy pStubHierarchy)
+        {
+            return 0;
+        }
+
+        public int OnQueryCloseProject(IVsHierarchy pHierarchy, int fRemoving, ref int pfCancel)
+        {
+            return 0;
+        }
+
+        public int OnQueryCloseSolution(object pUnkReserved, ref int pfCancel)
+        {
+            return 0;
+        }
+
+        public int OnQueryUnloadProject(IVsHierarchy pRealHierarchy, ref int pfCancel)
+        {
+            return 0;
+        }
+
+        public int OnAfterAsynchOpenProject(IVsHierarchy pHierarchy, int fAdded)
+        {
+            return 0;
+        }
+
+        public int OnAfterChangeProjectParent(IVsHierarchy pHierarchy)
+        {
+            return 0;
+        }
+
+        public int OnAfterRenameProject(IVsHierarchy pHierarchy)
+        {
+            //uint result = 0;
+            //pHierarchy.AdviseHierarchyEvents(new VsHierarchyEvents(pHierarchy), out result);
+            return 0;
+        }
+
+        public int OnQueryChangeProjectParent(IVsHierarchy pHierarchy, IVsHierarchy pNewParentHier, ref int pfCancel)
+        {
+            return 0;
+        }
+    }
+}

--- a/CppMonitor/Util/CopyUtil.cs
+++ b/CppMonitor/Util/CopyUtil.cs
@@ -1,4 +1,5 @@
 ﻿using EnvDTE;
+using Microsoft.VisualStudio.Shell;
 using NanjingUniversity.CppMonitor.Common;
 using System;
 using System.Collections.Generic;
@@ -8,12 +9,13 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
-namespace NanjingUniversity.CppMonitor.Monitor.FileMonitor
+namespace NanjingUniversity.CppMonitor.Util
 {
     class CopyUtil
     {
         public static String backupStartDirPath = Path.Combine(AddressCommon.FileModuleRootPath,"start_files");
         public static String backupMiddleDirPath = Path.Combine(AddressCommon.FileModuleRootPath, "middle_files");
+        public static String backupBuildDirPath = Path.Combine(AddressCommon.FileModuleRootPath, "build_files");
 
         public static void copyDir(string sourceDir, string targetDir)
         {
@@ -100,6 +102,21 @@ namespace NanjingUniversity.CppMonitor.Monitor.FileMonitor
             }
 
             return containsFile;
+        }
+
+        //将解决方案下文件完整备份
+        public static void backupSolutionFile(String targetPath){
+            DTE dte = (DTE)ServiceProvider.GlobalProvider.GetService(typeof(EnvDTE.DTE));
+            Projects projects = dte.Solution.Projects;
+
+            if (!Directory.Exists(targetPath))
+            {
+                Directory.CreateDirectory(targetPath);
+            }
+            foreach (Project project in projects)
+            {
+                CopyUtil.copyProjectFilesToTmp(project.ProjectItems, Path.Combine(targetPath, project.Name));
+            }
         }
     }
 }


### PR DESCRIPTION
1文件重命名操作
	追加三种修改类型（target file 记录的是源命名）
	5  文件重命名
	6  过滤器重命名
	7  项目重命名

如果需要解决方案重命名 再追加

2. 文件保存命令时

	content_info 已经有文件路径  可以解析出来文件名  
	content_info 添加了项目名

	文件保存命令  增加了项目名
	复制粘贴剪切命令  尽可能的补全了项目名  （如果操作直接影响到了VS中的一个文件 那么取到的项目名是绝对正确的，    否则只是参考的当前活跃项目名）

	解决方案名没有增加，因为可以通过解决方案的打开和关闭来区分一段操作


4. Build保存文件快照
	完成   根文件夹名为timemark  可以通过build时间戳去寻找对应的版本

发现问题：
	由于build info是异步取得  可能会丢失信息